### PR TITLE
Add interactive web UI for scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # fluid-ai-calendar
-An AI-Powered adaptive, time-blocking calendar that uses chat input and intelligent rescheduling
+An AI-powered adaptive, time-blocking calendar that uses chat input and intelligent rescheduling.
+
+## Running
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Start the server:
+
+```bash
+python src/app.py
+```
+
+3. Open [http://localhost:5000](http://localhost:5000) in your browser to use the web interface.
+
+The web UI lets you add tasks, generate schedules and view them on an interactive calendar.

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -1,21 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
-    var calendar = new FullCalendar.Calendar(calendarEl, {
-        initialView: 'timeGridWeek',
-        headerToolbar: {
-            left: 'prev,next today',
-            center: 'title',
-            right: 'dayGridMonth,timeGridWeek'
-        },
-        events: fetchEvents,
-        eventDidMount: function(info) {
-            var color = info.event.extendedProps.color || '#3788d8';
-            info.el.style.backgroundColor = hexToRgba(color, 0.2);
-            info.el.style.borderLeft = '4px solid ' + color;
-            info.el.style.color = '#fff';
-        }
-    });
-    calendar.render();
 
     function fetchEvents(fetchInfo, successCallback, failureCallback) {
         fetch('/schedule', {
@@ -44,6 +28,60 @@ document.addEventListener('DOMContentLoaded', function() {
         })
         .catch(failureCallback);
     }
+
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'timeGridWeek',
+        headerToolbar: {
+            left: 'prev,next today',
+            center: 'title',
+            right: 'dayGridMonth,timeGridWeek'
+        },
+        events: fetchEvents,
+        eventDidMount: function(info) {
+            var color = info.event.extendedProps.color || '#3788d8';
+            info.el.style.backgroundColor = hexToRgba(color, 0.2);
+            info.el.style.borderLeft = '4px solid ' + color;
+            info.el.style.color = '#fff';
+        }
+    });
+    calendar.render();
+
+    var taskForm = document.getElementById('task-form');
+    var fixedCheckbox = document.getElementById('fixed');
+    var startTimeField = document.getElementById('start-time-field');
+    var scheduleBtn = document.getElementById('schedule-btn');
+
+    fixedCheckbox.addEventListener('change', function() {
+        startTimeField.style.display = fixedCheckbox.checked ? 'block' : 'none';
+    });
+
+    taskForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        var payload = {
+            title: document.getElementById('title').value,
+            duration: parseInt(document.getElementById('duration').value, 10),
+            priority: document.getElementById('priority').value,
+            fixed: fixedCheckbox.checked
+        };
+        if (fixedCheckbox.checked) {
+            payload.start_time = document.getElementById('start_time').value;
+        }
+        fetch('/add-task', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(payload)
+        })
+        .then(resp => resp.json())
+        .then(function() {
+            taskForm.reset();
+            startTimeField.style.display = 'none';
+            calendar.refetchEvents();
+        });
+    });
+
+    scheduleBtn.addEventListener('click', function() {
+        calendar.refetchEvents();
+    });
 
     function hexToRgba(hex, alpha) {
         var r = parseInt(hex.slice(1, 3), 16);

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -2,7 +2,7 @@ body {
     background-color: #121212;
     color: #eee;
     margin: 0;
-    font-family: Arial, sans-serif;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 .fc .fc-toolbar-title {
@@ -30,4 +30,25 @@ body {
 .fc-event {
     border: none;
     color: #fff;
+}
+
+/* Form styling */
+.box {
+    background-color: #1e1e1e;
+}
+
+input.input, select.select, .select select {
+    background-color: #2c2c2c;
+    border-color: #444;
+    color: #eee;
+}
+
+button.button.is-primary {
+    background-color: #00d1b2;
+    border: none;
+}
+
+button.button.is-link {
+    background-color: #3273dc;
+    border: none;
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,12 +4,66 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fluid AI Calendar</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
-<body>
-    <div id="calendar"></div>
+<body class="has-background-dark has-text-light">
+    <section class="section">
+        <div class="container">
+            <h1 class="title has-text-white has-text-centered">Fluid AI Calendar</h1>
+            <div class="columns is-variable is-6">
+                <div class="column is-one-third">
+                    <form id="task-form" class="box">
+                        <h2 class="subtitle">Add Task</h2>
+                        <div class="field">
+                            <label class="label">Title</label>
+                            <div class="control">
+                                <input class="input" type="text" id="title" required>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <label class="label">Duration (minutes)</label>
+                            <div class="control">
+                                <input class="input" type="number" id="duration" min="1" required>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <label class="label">Priority</label>
+                            <div class="control">
+                                <div class="select is-fullwidth">
+                                    <select id="priority">
+                                        <option value="low">Low</option>
+                                        <option value="medium" selected>Medium</option>
+                                        <option value="high">High</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <label class="checkbox">
+                                <input type="checkbox" id="fixed"> Fixed time
+                            </label>
+                        </div>
+                        <div class="field" id="start-time-field" style="display:none;">
+                            <label class="label">Start Time</label>
+                            <div class="control">
+                                <input class="input" type="time" id="start_time">
+                            </div>
+                        </div>
+                        <div class="field">
+                            <button class="button is-primary is-fullwidth" type="submit">Add Task</button>
+                        </div>
+                    </form>
+                    <button id="schedule-btn" class="button is-link is-fullwidth mt-2">Generate Schedule</button>
+                </div>
+                <div class="column">
+                    <div id="calendar"></div>
+                </div>
+            </div>
+        </div>
+    </section>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Build Bulma-based frontend with task form and schedule button
- Enhance calendar script to add tasks and refresh schedule dynamically
- Expand styling and README instructions for new web UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896dfded198832081ebb72339aa9133