### PR TITLE
Add interactive web UI for scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # fluid-ai-calendar
-An AI-Powered adaptive, time-blocking calendar that uses chat input and intelligent rescheduling
+An AI-powered adaptive, time-blocking calendar that uses chat input and intelligent rescheduling.
+
+## Running
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Ensure an OpenAI API key is available:
+
+```bash
+export OPENAI_API_KEY="your-key"
+```
+
+3. Start the server:
+
+```bash
+python src/app.py
+```
+
+4. Open [http://localhost:5000](http://localhost:5000) in your browser to use the web interface.
+
+Use the prompt box to describe tasks in natural language ("Schedule a 30‑minute call tomorrow at 2 PM") and the assistant will add and schedule them automatically on the interactive calendar.

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -1,21 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('calendar');
-    var calendar = new FullCalendar.Calendar(calendarEl, {
-        initialView: 'timeGridWeek',
-        headerToolbar: {
-            left: 'prev,next today',
-            center: 'title',
-            right: 'dayGridMonth,timeGridWeek'
-        },
-        events: fetchEvents,
-        eventDidMount: function(info) {
-            var color = info.event.extendedProps.color || '#3788d8';
-            info.el.style.backgroundColor = hexToRgba(color, 0.2);
-            info.el.style.borderLeft = '4px solid ' + color;
-            info.el.style.color = '#fff';
-        }
-    });
-    calendar.render();
 
     function fetchEvents(fetchInfo, successCallback, failureCallback) {
         fetch('/schedule', {
@@ -44,6 +28,40 @@ document.addEventListener('DOMContentLoaded', function() {
         })
         .catch(failureCallback);
     }
+
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+        initialView: 'timeGridWeek',
+        headerToolbar: {
+            left: 'prev,next today',
+            center: 'title',
+            right: 'dayGridMonth,timeGridWeek'
+        },
+        events: fetchEvents,
+        eventDidMount: function(info) {
+            var color = info.event.extendedProps.color || '#3788d8';
+            info.el.style.backgroundColor = hexToRgba(color, 0.2);
+            info.el.style.borderLeft = '4px solid ' + color;
+            info.el.style.color = '#fff';
+        }
+    });
+    calendar.render();
+
+    var promptForm = document.getElementById('prompt-form');
+    promptForm.addEventListener('submit', function(e) {
+        e.preventDefault();
+        var text = document.getElementById('prompt').value.trim();
+        if (!text) return;
+        fetch('/natural-schedule', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({prompt: text})
+        })
+        .then(resp => resp.json())
+        .then(function() {
+            promptForm.reset();
+            calendar.refetchEvents();
+        });
+    });
 
     function hexToRgba(hex, alpha) {
         var r = parseInt(hex.slice(1, 3), 16);

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -2,7 +2,7 @@ body {
     background-color: #121212;
     color: #eee;
     margin: 0;
-    font-family: Arial, sans-serif;
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 }
 
 .fc .fc-toolbar-title {
@@ -30,4 +30,31 @@ body {
 .fc-event {
     border: none;
     color: #fff;
+}
+
+/* Form styling */
+.box {
+    background-color: #1e1e1e;
+}
+
+input.input, select.select, .select select {
+    background-color: #2c2c2c;
+    border-color: #444;
+    color: #eee;
+}
+
+textarea.textarea {
+    background-color: #2c2c2c;
+    border-color: #444;
+    color: #eee;
+}
+
+button.button.is-primary {
+    background-color: #00d1b2;
+    border: none;
+}
+
+button.button.is-link {
+    background-color: #3273dc;
+    border: none;
 }

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -4,12 +4,36 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Fluid AI Calendar</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.js"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
-<body>
-    <div id="calendar"></div>
+<body class="has-background-dark has-text-light">
+    <section class="section">
+        <div class="container">
+            <h1 class="title has-text-white has-text-centered">Fluid AI Calendar</h1>
+            <div class="columns is-variable is-6">
+                <div class="column is-one-third">
+                    <form id="prompt-form" class="box">
+                        <h2 class="subtitle">Ask the assistant</h2>
+                        <div class="field">
+                            <label class="label">Prompt</label>
+                            <div class="control">
+                                <textarea class="textarea" id="prompt" rows="3" placeholder="e.g., Schedule a 30 min call tomorrow at 2pm" required></textarea>
+                            </div>
+                        </div>
+                        <div class="field">
+                            <button class="button is-primary is-fullwidth" type="submit">Send</button>
+                        </div>
+                    </form>
+                </div>
+                <div class="column">
+                    <div id="calendar"></div>
+                </div>
+            </div>
+        </div>
+    </section>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace manual task form with a chat-style prompt box for natural language scheduling
- Wire frontend to `/natural-schedule` so AI-parsed tasks are scheduled and displayed on the calendar
- Document OpenAI key setup and prompt-driven usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896dfded198832081ebb72339aa9133